### PR TITLE
[FIXED]annotateとi18nのgemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'rails-i18n'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -61,6 +62,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'scss_lint', require: false
   gem 'rubocop', require: false
+  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ancestry (3.0.7)
       activerecord (>= 3.2.0)
+    annotate (3.0.3)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -389,6 +392,7 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   ancestry
+  annotate
   bootsnap (>= 1.1.0)
   byebug
   capistrano


### PR DESCRIPTION
 ### Done
- [x] モデル定義に必要そうな最低限のgemを追加しました。
- annotate: データーベースのモデル定義をマイグレーションする度にmodelファイルに自動で書き込んでくれる。
https://rubygems.org/gems/annotate

- rails-i18n: 多言語対応（Railsが自動で表示してしまうカラム名等を日本語に対応したりできたりする）
https://rubygems.org/gems/rails-i18n
---
